### PR TITLE
choose skill type after applying multipliers

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             double flowDifficulty = FlowAimEvaluator.EvaluateDifficultyOf(current);
             double agilityDifficulty = AgilityEvaluator.EvaluateDifficultyOf(current);
 
-            bool isFlow = (flowDifficulty) < (snapDifficulty + agilityDifficulty);
+            bool isFlow = (flowDifficulty * flowMultiplier) < (snapDifficulty * snapMultiplier + agilityDifficulty * agilityMultiplier);
 
             if (isFlow)
             {


### PR DESCRIPTION
should make it so pp can't suddenly jump (or drop) when moving an object a single pixel